### PR TITLE
proper request log rerender

### DIFF
--- a/src/static/components/endpoint-page.vue
+++ b/src/static/components/endpoint-page.vue
@@ -8,8 +8,8 @@
 
             <div class="request-logs">
                 <request-log
-                    v-for="(requestLog, index) in requestLogs"
-                    :key="index"
+                    v-for="requestLog in requestLogs"
+                    :key="requestLog.id"
                     :data="requestLog">
                 </request-log>
             </div>

--- a/src/static/components/request-log.vue
+++ b/src/static/components/request-log.vue
@@ -7,9 +7,9 @@
             <time class="timestamp" :datetime="data.timestamp">{{ date }}</time>
         </header>
 
-        <request-details class="section" v-if="isExpanded" :data="data.request"></request-details>
-        <response-details class="section" v-if="isExpanded && data.response" :data="data.response"></response-details>
-        <response-form class="section" v-if="isExpanded && !data.response" @submit="onResponse"></response-form>
+        <request-details class="section" v-if="data.isExpanded" :data="data.request"></request-details>
+        <response-details class="section" v-if="data.isExpanded && data.response" :data="data.response"></response-details>
+        <response-form class="section" v-if="data.isExpanded && !data.response" @submit="onResponse"></response-form>
     </section>
 </template>
 
@@ -18,12 +18,6 @@
 
     export default {
         props: ['data'],
-
-        data() {
-            return {
-                isExpanded: false
-            };
-        },
 
         computed: {
             method() {
@@ -44,7 +38,12 @@
 
         methods: {
             toggleExpanded() {
-                this.isExpanded = !this.isExpanded;
+                this.$store.commit('updateRequestLog', {
+                    id: this.data.id,
+                    updateData: {
+                        isExpanded: !this.data.isExpanded
+                    }
+                });
             },
 
             getStatusCodeClass(status) {

--- a/src/static/store.js
+++ b/src/static/store.js
@@ -48,7 +48,10 @@ export default new Vuex.Store({
         },
 
         insertRequestLog(state, requestLog) {
-            state.bufferedRequestLogs = [requestLog, ...state.bufferedRequestLogs];
+            state.bufferedRequestLogs = [
+                Object.assign({}, requestLog, { isExpanded: false }),
+                ...state.bufferedRequestLogs
+            ];
         },
 
         flushRequestLogs(state) {

--- a/src/static/store.js
+++ b/src/static/store.js
@@ -79,7 +79,9 @@ export default new Vuex.Store({
 
         async fetchRequestLogs(context) {
             const logsEndpoint = `/${context.state.hash}/logs`;
-            const requestLogs = await fetch(logsEndpoint).then(response => response.json());
+            let requestLogs = await fetch(logsEndpoint).then(response => response.json());
+            requestLogs = requestLogs.map(requestLog =>
+                Object.assign({}, requestLog, { isExpanded: false }));
             context.commit('setRequestLogs', requestLogs);
         },
 


### PR DESCRIPTION
Fixes #32 by storing the `isExpanded` state in the Vuex store instead of inside the `request-log` component's data.